### PR TITLE
fix(): refactoring metric factory to accept prefix for the metrics

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -27,6 +27,9 @@ type metricsFactory struct {
 }
 
 func NewMetricsFactory(r prometheus.Registerer, o MetricsFactoryOptions) (MetricsFactory, error) {
+	if o.Prefix == "" {
+		o.Prefix = "kubeslice"
+	}
 	mf := &metricsFactory{
 		Registerer: r,
 		Options:    o,
@@ -58,12 +61,8 @@ func (m *metricsFactory) getCurryLabels(labels []string) ([]string, prometheus.L
 
 func (m *metricsFactory) NewCounter(name string, help string, labels []string) *prometheus.CounterVec {
 	labels, cl := m.getCurryLabels(labels)
-	ns := "kubeslice"
-	if m.Options.Prefix != "" {
-		ns = m.Options.Prefix
-	}
 	return promauto.With(m.Registerer).NewCounterVec(prometheus.CounterOpts{
-		Namespace: ns,
+		Namespace: m.Options.Prefix,
 		Name:      name,
 		Help:      help,
 	}, labels).MustCurryWith(cl)
@@ -71,12 +70,8 @@ func (m *metricsFactory) NewCounter(name string, help string, labels []string) *
 
 func (m *metricsFactory) NewGauge(name string, help string, labels []string) *prometheus.GaugeVec {
 	labels, cl := m.getCurryLabels(labels)
-	ns := "kubeslice"
-	if m.Options.Prefix != "" {
-		ns = m.Options.Prefix
-	}
 	return promauto.With(m.Registerer).NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: ns,
+		Namespace: m.Options.Prefix,
 		Name:      name,
 		Help:      help,
 	}, labels).MustCurryWith(cl)
@@ -84,12 +79,8 @@ func (m *metricsFactory) NewGauge(name string, help string, labels []string) *pr
 
 func (m *metricsFactory) NewHistogram(name string, help string, labels []string) prometheus.ObserverVec {
 	labels, cl := m.getCurryLabels(labels)
-	ns := "kubeslice"
-	if m.Options.Prefix != "" {
-		ns = m.Options.Prefix
-	}
 	return promauto.With(m.Registerer).NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: ns,
+		Namespace: m.Options.Prefix,
 		Name:      name,
 		Help:      help,
 	}, labels).MustCurryWith(cl)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -18,6 +18,7 @@ type MetricsFactoryOptions struct {
 	Cluster             string
 	Namespace           string
 	ReportingController string
+	Prefix              string
 }
 
 type metricsFactory struct {
@@ -57,8 +58,12 @@ func (m *metricsFactory) getCurryLabels(labels []string) ([]string, prometheus.L
 
 func (m *metricsFactory) NewCounter(name string, help string, labels []string) *prometheus.CounterVec {
 	labels, cl := m.getCurryLabels(labels)
+	ns := "kubeslice"
+	if m.Options.Prefix != "" {
+		ns = m.Options.Prefix
+	}
 	return promauto.With(m.Registerer).NewCounterVec(prometheus.CounterOpts{
-		Namespace: "kubeslice",
+		Namespace: ns,
 		Name:      name,
 		Help:      help,
 	}, labels).MustCurryWith(cl)
@@ -66,8 +71,12 @@ func (m *metricsFactory) NewCounter(name string, help string, labels []string) *
 
 func (m *metricsFactory) NewGauge(name string, help string, labels []string) *prometheus.GaugeVec {
 	labels, cl := m.getCurryLabels(labels)
+	ns := "kubeslice"
+	if m.Options.Prefix != "" {
+		ns = m.Options.Prefix
+	}
 	return promauto.With(m.Registerer).NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "kubeslice",
+		Namespace: ns,
 		Name:      name,
 		Help:      help,
 	}, labels).MustCurryWith(cl)
@@ -75,8 +84,12 @@ func (m *metricsFactory) NewGauge(name string, help string, labels []string) *pr
 
 func (m *metricsFactory) NewHistogram(name string, help string, labels []string) prometheus.ObserverVec {
 	labels, cl := m.getCurryLabels(labels)
+	ns := "kubeslice"
+	if m.Options.Prefix != "" {
+		ns = m.Options.Prefix
+	}
 	return promauto.With(m.Registerer).NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "kubeslice",
+		Namespace: ns,
 		Name:      name,
 		Help:      help,
 	}, labels).MustCurryWith(cl)


### PR DESCRIPTION
- The Kubeslice Controller has old metrics with some prefix on it, which are being used in API-GW and the UI. Once we refactor those implementation with this framework, we should not change the existing metrics names. Hence, we introduced an optional field `Prefix` which can be set to maintain the old metric names.