### PR TITLE
fix(): empty namespace of involvedObject fixed

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -166,12 +166,16 @@ func (er *eventRecorder) WithProject(project string) EventRecorder {
 }
 
 // RecordEvent raises a new event with the given fields
-// TODO: events caching and aggregation
 func (er *eventRecorder) RecordEvent(ctx context.Context, e *Event) error {
 	ref, err := reference.GetReference(er.Scheme, e.Object)
 	if err != nil {
 		er.Logger.With("error", err).Error("Unable to parse event obj reference")
 		return err
+	}
+
+	if ref.Namespace == "" {
+		er.Logger.Debugf("reference namespace is empty using name instead ", ref.Name)
+		ref.Namespace = ref.Name
 	}
 
 	ns := er.Options.Namespace

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -195,7 +195,7 @@ func TestEventWithEmptyNamespaceReference(t *testing.T) {
 	if e.InvolvedObject.Name == "" {
 		t.Error("InvolvedObject Name is empty")
 	}
-	if e.InvolvedObject.Name == "" {
+	if e.InvolvedObject.Namespace == "" {
 		t.Error("InvolvedObject NameSpace is empty")
 	}
 	if e.InvolvedObject.Name != e.InvolvedObject.Namespace {


### PR DESCRIPTION
when involvedObject has an empty namespace (ex: namespace object)
we use the name of the object in the place of namespace.
This will fix the issue of creating an event key with
empty value for namespace field used in caching and aggregation.